### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,14 +11,14 @@ django-generic-helpers
 .. image:: https://coveralls.io/repos/marazmiki/django-generic-helpers/badge.png?branch=master
   :target: https://coveralls.io/r/marazmiki/django-generic-helpers?branch=master
 
-.. image:: https://pypip.in/d/django-generic-helpers/badge.png
+.. image:: https://img.shields.io/pypi/dm/django-generic-helpers.svg
         :target: https://pypi.python.org/pypi/django-generic-helpers
 
-.. image:: https://pypip.in/wheel/django-generic-helpers/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/django-generic-helpers.svg
     :target: https://pypi.python.org/pypi/django-generic-helpers/
     :alt: Wheel Status
 
-.. image:: https://pypip.in/py_versions/django-generic-helpers/badge.png
+.. image:: https://img.shields.io/pypi/pyversions/django-generic-helpers.svg
     :target: https://pypi.python.org/pypi/django-generic-helpers/
     :alt: Supported Python versions
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-generic-helpers))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-generic-helpers`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.